### PR TITLE
Add @AvroDefault annotation

### DIFF
--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/AnnotationExtractor.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/AnnotationExtractor.kt
@@ -19,5 +19,6 @@ class AnnotationExtractor(private val annotations: List<Annotation>) {
    fun doc(): String? = annotations.filterIsInstance<AvroDoc>().firstOrNull()?.value
    fun aliases(): List<String> = annotations.filterIsInstance<AvroAlias>().map { it.value }
    fun props(): List<Pair<String, String>> = annotations.filterIsInstance<AvroProp>().map { it.key to it.value }
+   fun default(): String? = annotations.filterIsInstance<AvroDefault>().firstOrNull()?.value
 }
 

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/annotations.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/annotations.kt
@@ -48,3 +48,7 @@ annotation class AvroAlias(val value: String)
 @SerialInfo
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class AvroFixed(val size: Int)
+
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+annotation class AvroDefault(val value: String)

--- a/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/schema/AvroDefaultSchemaTest.kt
+++ b/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/schema/AvroDefaultSchemaTest.kt
@@ -1,0 +1,51 @@
+package com.sksamuel.avro4k.schema
+
+import com.sksamuel.avro4k.Avro
+import com.sksamuel.avro4k.AvroDefault
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+import kotlinx.serialization.Serializable
+
+class AvroDefaultSchemaTest: FunSpec() {
+   init {
+      test("schema for data class with @AvroDefault should include default value as a string") {
+         val expected = org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/avro_default_annotation_string.json"))
+         val schema = Avro.default.schema(BarString.serializer())
+         schema.toString(true) shouldBe expected.toString(true)
+      }
+
+      test("schema for data class with @AvroDefault should include default value as an int") {
+         val expected = org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/avro_default_annotation_int.json"))
+         val schema = Avro.default.schema(BarInt.serializer())
+         schema.toString(true) shouldBe expected.toString(true)
+      }
+
+      test("schema for data class with @AvroDefault should include default value as a float") {
+         val expected = org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/avro_default_annotation_float.json"))
+         val schema = Avro.default.schema(BarFloat.serializer())
+         schema.toString(true) shouldBe expected.toString(true)
+      }
+   }
+}
+
+
+@Serializable
+data class BarString(
+   val a: String,
+   @AvroDefault("hello")
+   val b: String
+)
+
+@Serializable
+data class BarInt(
+   val a: String,
+   @AvroDefault("5")
+   val b: Int
+)
+
+@Serializable
+data class BarFloat(
+   val a: String,
+   @AvroDefault("3.14")
+   val b: Float
+)

--- a/avro4k-core/src/test/resources/avro_default_annotation_float.json
+++ b/avro4k-core/src/test/resources/avro_default_annotation_float.json
@@ -1,0 +1,16 @@
+{
+   "type": "record",
+   "name": "BarFloat",
+   "namespace": "com.sksamuel.avro4k.schema",
+   "fields": [
+      {
+         "name": "a",
+         "type": "string"
+      },
+      {
+         "name": "b",
+         "type": "float",
+         "default": 3.14
+      }
+   ]
+}

--- a/avro4k-core/src/test/resources/avro_default_annotation_int.json
+++ b/avro4k-core/src/test/resources/avro_default_annotation_int.json
@@ -1,0 +1,16 @@
+{
+   "type": "record",
+   "name": "BarInt",
+   "namespace": "com.sksamuel.avro4k.schema",
+   "fields": [
+      {
+         "name": "a",
+         "type": "string"
+      },
+      {
+         "name": "b",
+         "type": "int",
+         "default": 5
+      }
+   ]
+}

--- a/avro4k-core/src/test/resources/avro_default_annotation_string.json
+++ b/avro4k-core/src/test/resources/avro_default_annotation_string.json
@@ -1,0 +1,16 @@
+{
+   "type": "record",
+   "name": "BarString",
+   "namespace": "com.sksamuel.avro4k.schema",
+   "fields": [
+      {
+         "name": "a",
+         "type": "string"
+      },
+      {
+         "name": "b",
+         "type": "string",
+         "default": "hello"
+      }
+   ]
+}


### PR DESCRIPTION
Hey @sksamuel! Thank you for your work on this project; it's a great library.

For this feature, I followed the API provided by the [`@AvroDefault`](https://avro.apache.org/docs/1.8.0/api/java/org/apache/avro/reflect/AvroDefault.html) annotation. 

I was a little hesitant to have the function take in a `String`, but it is one of the simpler choices, and there's already an existing API that does it, so I think it's fine. I believe they define it as a JSON string.

Ideally it'd be a generic type, but you can't use generic types with annotation classes.

# How It Works
* Added the `@AvroDefault` in the same format as the other annotations in the project
* the key lines are these:
```kotlin
val default: Any? = annos.default()?.let {
    when(fieldDescriptor.kind) {
        PrimitiveKind.INT -> it.toInt()
        PrimitiveKind.LONG -> it.toLong()
        PrimitiveKind.FLOAT -> it.toFloat()
        PrimitiveKind.BOOLEAN -> it.toBoolean()
        PrimitiveKind.BYTE -> it.toByte()
        PrimitiveKind.SHORT -> it.toShort()
        PrimitiveKind.STRING -> it
        PrimitiveKind.UNIT -> null
        else -> throw IllegalArgumentException("Cannot use a default value for type ${fieldDescriptor.kind}")
    }
}

val field = Schema.Field(fieldNaming.name(), schemaWithResolvedNamespace, annos.doc(), default)
```
* added tests