### PR TITLE
Migrate to kotlinx.serialization 0.14

### DIFF
--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/decoder/ListDecoder.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/decoder/ListDecoder.kt
@@ -51,7 +51,7 @@ class ListDecoder(private val schema: Schema,
 
    override fun fieldSchema(): Schema = schema.elementType
 
-   override fun decodeEnum(enumDescription: EnumDescriptor): Int {
+   override fun decodeEnum(enumDescription: SerialDescriptor): Int {
       val symbol = EnumFromAvroValue.fromValue(array[index++]!!)
       return (0 until enumDescription.elementsCount).find { enumDescription.getElementName(it) == symbol } ?: -1
    }

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/decoder/RecordDecoder.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/decoder/RecordDecoder.kt
@@ -101,7 +101,7 @@ class RecordDecoder(private val desc: SerialDescriptor,
       return fieldValue() != null
    }
 
-   override fun decodeEnum(enumDescription: EnumDescriptor): Int {
+   override fun decodeEnum(enumDescription: SerialDescriptor): Int {
       val symbol = EnumFromAvroValue.fromValue(fieldValue()!!)
       return (0 until enumDescription.elementsCount).find { enumDescription.getElementName(it) == symbol } ?: -1
    }

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/ListEncoder.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/ListEncoder.kt
@@ -72,7 +72,7 @@ class ListEncoder(private val schema: Schema,
       list.add(value)
    }
 
-   override fun encodeEnum(enumDescription: EnumDescriptor, ordinal: Int) {
+   override fun encodeEnum(enumDescription: SerialDescriptor, ordinal: Int) {
       list.add(ValueToEnum.toValue(fieldSchema(), enumDescription, ordinal))
    }
 }

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/RecordEncoder.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/RecordEncoder.kt
@@ -76,7 +76,7 @@ class RecordEncoder(private val schema: Schema,
       builder.add(fixed)
    }
 
-   override fun encodeEnum(enumDescription: EnumDescriptor, ordinal: Int) {
+   override fun encodeEnum(enumDescription: SerialDescriptor, ordinal: Int) {
       builder.add(ValueToEnum.toValue(fieldSchema(), enumDescription, ordinal))
    }
 

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/schema/SchemaFor.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/schema/SchemaFor.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4k.schema
 
 import com.sksamuel.avro4k.RecordNaming
+import kotlinx.serialization.PolymorphicKind
 import kotlinx.serialization.PrimitiveKind
 import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.SerializationException
@@ -137,7 +138,7 @@ fun schemaFor(context: SerialModule,
          PrimitiveKind.FLOAT -> SchemaFor.FloatSchemaFor
          PrimitiveKind.BOOLEAN -> SchemaFor.BooleanSchemaFor
          UnionKind.ENUM_KIND -> EnumSchemaFor(descriptor)
-         UnionKind.SEALED -> SealedClassSchemaFor(descriptor)
+         PolymorphicKind.SEALED -> SealedClassSchemaFor(descriptor)
          StructureKind.CLASS -> when (descriptor.name) {
             "kotlin.Pair" -> PairSchemaFor(descriptor, namingStrategy, context)
             else -> ClassSchemaFor(descriptor, namingStrategy, context)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
    ext.isReleaseVersion = !isTravis
 
    ext.kotlin_version = '1.3.61'
-   ext.serializationVersion = "0.13.0"
+   ext.serializationVersion = "0.14.0"
    ext.avroVersion = "1.90.1"
    ext.kotlinTestVersion = "3.4.2"
 
@@ -23,7 +23,7 @@ buildscript {
 }
 
 plugins {
-   id 'org.jetbrains.kotlin.jvm' version '1.3.50'
+   id 'org.jetbrains.kotlin.jvm' version '1.3.61'
    id 'org.jetbrains.kotlin.plugin.serialization' version '1.3.61'
 }
 


### PR DESCRIPTION
Started using this library together with ktor's ContentNegotiation with kotlinx.serialization. Unfortunately 0.20 couldn't be used with ktor 1.3.0 as ktor brings along kotlinx.serialization:0.14, causing the comparison for UnionKind.SEALED to fail, because the UnionKind.SEALED no longer exists in 0.14.

This PR bumps kotlinx.serialization to 0.14, and makes the necessary override changes for List/Record Encoder and Decoders.