### PR TITLE
Added new annotation @AvroAliases to support multiple aliases.

### DIFF
--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/AnnotationExtractor.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/AnnotationExtractor.kt
@@ -17,7 +17,12 @@ class AnnotationExtractor(private val annotations: List<Annotation>) {
    fun name(): String? = annotations.filterIsInstance<AvroName>().firstOrNull()?.value
    fun valueType(): Boolean = annotations.filterIsInstance<AvroInline>().isNotEmpty()
    fun doc(): String? = annotations.filterIsInstance<AvroDoc>().firstOrNull()?.value
-   fun aliases(): List<String> = annotations.filterIsInstance<AvroAlias>().map { it.value }
+   fun aliases(): List<String> =
+      if(annotations.any { it is AvroAlias }){
+         annotations.filterIsInstance<AvroAlias>().map { it.value }
+      }else{
+         annotations.filterIsInstance<AvroAliases>().flatMap { it.value.toList() }
+      }
    fun props(): List<Pair<String, String>> = annotations.filterIsInstance<AvroProp>().map { it.key to it.value }
    fun default(): String? = annotations.filterIsInstance<AvroDefault>().firstOrNull()?.value
 }

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/annotations.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/annotations.kt
@@ -30,6 +30,10 @@ annotation class AvroDoc(val value: String)
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class AvroAlias(val value: String)
 
+@SerialInfo
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+annotation class AvroAliases(val value: Array<String>)
+
 /**
  * [AvroFixed] overrides the schema type for a field or a value class
  * so that the schema is set to org.apache.avro.Schema.Type.FIXED

--- a/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/schema/AvroAliasSchemaTest.kt
+++ b/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/schema/AvroAliasSchemaTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.avro4k.schema
 
 import com.sksamuel.avro4k.Avro
 import com.sksamuel.avro4k.AvroAlias
+import com.sksamuel.avro4k.AvroAliases
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 import kotlinx.serialization.Serializable
@@ -19,17 +20,16 @@ class AvroAliasSchemaTest : WordSpec({
       val schema = Avro.default.schema(Annotated.serializer())
       schema.toString(true) shouldBe expected.toString(true)
     }
-//    "support multiple alias annotations on types"  {
-//
-//      @AvroAlias("queen")
-//      @AvroAlias("ledzep")
-//      @Serializable
-//      data class Annotated(val str: String)
-//
-//      val expected = org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/aliases_on_types_multiple.json"))
-//      val schema = Avro.default.schema(Annotated.serializer())
-//      schema.toString(true) shouldBe expected.toString(true)
-//    }
+    "support multiple alias annotations on types"  {
+
+      @AvroAliases(["queen","ledzep"])
+      @Serializable
+      data class Annotated(val str: String)
+
+      val expected = org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/aliases_on_types_multiple.json"))
+      val schema = Avro.default.schema(Annotated.serializer())
+      schema.toString(true) shouldBe expected.toString(true)
+    }
     "support alias annotations on field"  {
 
       @Serializable
@@ -39,6 +39,15 @@ class AvroAliasSchemaTest : WordSpec({
       val schema = Avro.default.schema(Annotated.serializer())
       schema.toString(true) shouldBe expected.toString(true)
     }
+     "support multiple alias annotations on fields"  {
+
+        @Serializable
+        data class Annotated(@AvroAliases(["queen","ledzep"]) val str: String)
+
+        val expected = org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/aliases_on_fields_multiple.json"))
+        val schema = Avro.default.schema(Annotated.serializer())
+        schema.toString(true) shouldBe expected.toString(true)
+     }
   }
 
 })

--- a/avro4k-core/src/test/resources/aliases_on_fields_multiple.json
+++ b/avro4k-core/src/test/resources/aliases_on_fields_multiple.json
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "Annotated",
+  "namespace": "com.sksamuel.avro4k.schema.AvroAliasSchemaTest",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+       "aliases": [
+          "queen",
+          "ledzep"
+       ]
+    }
+  ]
+}


### PR DESCRIPTION
Fix for #25 

Adding a new AvroAliases annotation that supports multiple aliases as in avro spec. I didn't reuse the AvroAlias annotation for this, because a list of strings is closer to the Avro spec. 