### PR TITLE
Fixed incorrect handling of avro null default values.

### DIFF
--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/Avro.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/Avro.kt
@@ -107,6 +107,10 @@ class Avro(override val context: SerialModule = EmptyModule) : AbstractSerialFor
          UUID::class to UUIDSerializer())
       )
       val default = Avro(simpleModule)
+      /**
+       * Use this constant if you want to explicitly set a default value of a field to avro null
+       */
+      const val NULL = "com.sksamuel.avro4k.Avro.AVRO_NULL_DEFAULT"
    }
 
    /**

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/schema/ClassSchemaFor.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/schema/ClassSchemaFor.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.avro4k.schema
 
 import com.sksamuel.avro4k.AnnotationExtractor
+import com.sksamuel.avro4k.Avro
 import com.sksamuel.avro4k.AvroProp
 import com.sksamuel.avro4k.RecordNaming
 import kotlinx.serialization.PrimitiveKind
@@ -83,16 +84,20 @@ class ClassSchemaFor(private val descriptor: SerialDescriptor,
       }
 
       val default: Any? = annos.default()?.let {
-         when(fieldDescriptor.kind) {
-            PrimitiveKind.INT -> it.toInt()
-            PrimitiveKind.LONG -> it.toLong()
-            PrimitiveKind.FLOAT -> it.toFloat()
-            PrimitiveKind.BOOLEAN -> it.toBoolean()
-            PrimitiveKind.BYTE -> it.toByte()
-            PrimitiveKind.SHORT -> it.toShort()
-            PrimitiveKind.STRING -> it
-            PrimitiveKind.UNIT -> null
-            else -> throw IllegalArgumentException("Cannot use a default value for type ${fieldDescriptor.kind}")
+         if(it == Avro.NULL){
+            Schema.Field.NULL_DEFAULT_VALUE
+         }else {
+            when (fieldDescriptor.kind) {
+               PrimitiveKind.INT -> it.toInt()
+               PrimitiveKind.LONG -> it.toLong()
+               PrimitiveKind.FLOAT -> it.toFloat()
+               PrimitiveKind.BOOLEAN -> it.toBoolean()
+               PrimitiveKind.BYTE -> it.toByte()
+               PrimitiveKind.SHORT -> it.toShort()
+               PrimitiveKind.STRING -> it
+               PrimitiveKind.UNIT -> null
+               else -> throw IllegalArgumentException("Cannot use a default value for type ${fieldDescriptor.kind}")
+            }
          }
       }
 

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/schema/schemas.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/schema/schemas.kt
@@ -6,10 +6,10 @@ import org.apache.avro.Schema
 // union schemas can't contain other union schemas as a direct
 // child, so whenever we create a union, we need to check if our
 // children are unions and flatten
-fun createSafeUnion(vararg schemas: Schema): Schema {
+fun createSafeUnion(nullFirst : Boolean,vararg schemas: Schema): Schema {
    val flattened = schemas.flatMap { schema -> runCatching { schema.types }.getOrElse { listOf(schema) } }
    val (nulls, rest) = flattened.partition { it.type == Schema.Type.NULL }
-   return Schema.createUnion(nulls + rest)
+   return Schema.createUnion(if(nullFirst) nulls + rest else rest + nulls)
 }
 
 fun Schema.findSubschema(name: String): Schema? {

--- a/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/schema/AvroDefaultSchemaTest.kt
+++ b/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/schema/AvroDefaultSchemaTest.kt
@@ -33,19 +33,32 @@ class AvroDefaultSchemaTest: FunSpec() {
 data class BarString(
    val a: String,
    @AvroDefault("hello")
-   val b: String
+   val b: String,
+   @AvroDefault(Avro.NULL)
+   val nullableString : String?,
+   @AvroDefault("hello")
+   val c:String?
 )
 
 @Serializable
 data class BarInt(
    val a: String,
    @AvroDefault("5")
-   val b: Int
+   val b: Int,
+   @AvroDefault(Avro.NULL)
+   val nullableInt : Int?,
+   @AvroDefault("5")
+   val c:Int?
 )
 
 @Serializable
 data class BarFloat(
    val a: String,
    @AvroDefault("3.14")
-   val b: Float
+   val b: Float,
+   @AvroDefault(Avro.NULL)
+   val nullableFloat : Float?,
+   @AvroDefault("3.14")
+   val c:Float?
+
 )

--- a/avro4k-core/src/test/resources/avro_default_annotation_float.json
+++ b/avro4k-core/src/test/resources/avro_default_annotation_float.json
@@ -11,6 +11,16 @@
          "name": "b",
          "type": "float",
          "default": 3.14
+      },
+      {
+         "name": "nullableFloat",
+         "type": ["null","float"],
+         "default" : null
+      },
+      {
+         "name": "c",
+         "type": ["float","null"],
+         "default": 3.14
       }
    ]
 }

--- a/avro4k-core/src/test/resources/avro_default_annotation_int.json
+++ b/avro4k-core/src/test/resources/avro_default_annotation_int.json
@@ -11,6 +11,16 @@
          "name": "b",
          "type": "int",
          "default": 5
+      },
+      {
+         "name": "nullableInt",
+         "type": ["null","int"],
+         "default" : null
+      },
+      {
+         "name": "c",
+         "type": ["int","null"],
+         "default" : 5
       }
    ]
 }

--- a/avro4k-core/src/test/resources/avro_default_annotation_string.json
+++ b/avro4k-core/src/test/resources/avro_default_annotation_string.json
@@ -11,6 +11,16 @@
          "name": "b",
          "type": "string",
          "default": "hello"
+      },
+      {
+         "name": "nullableString",
+         "type": ["null","string"],
+         "default" : null
+      },
+      {
+         "name": "c",
+         "type": ["string","null"],
+         "default": "hello"
       }
    ]
 }


### PR DESCRIPTION
If a default is specified for a union, the default must be an instance of the first type in the union. Thus the generated schema needs to check the default definition when generating the union schema.

Additionally added a Avro.NULL constant that should be used to indicate a avro null default.

This is a fix for #27 