### PR TITLE
Rewind created instances of ByteBuffer before returning them

### DIFF
--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoder.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoder.kt
@@ -29,7 +29,7 @@ class ByteArrayEncoder(private val schema: Schema,
                .array()
             callback(GenericData.get().createFixed(null, padded, schema))
          }
-         Schema.Type.BYTES -> callback(ByteBuffer.allocate(bytes.size).put(bytes.toByteArray()))
+         Schema.Type.BYTES -> callback(ByteBuffer.allocate(bytes.size).put(bytes.toByteArray()).rewind())
          else -> throw SerializationException("Cannot encode byte array when schema is ${schema.type}")
       }
 

--- a/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoder.kt
+++ b/avro4k-core/src/main/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoder.kt
@@ -29,7 +29,8 @@ class ByteArrayEncoder(private val schema: Schema,
                .array()
             callback(GenericData.get().createFixed(null, padded, schema))
          }
-         Schema.Type.BYTES -> callback(ByteBuffer.allocate(bytes.size).put(bytes.toByteArray()).rewind())
+         //Wrapping the resulting byte array directly as this does not duplicate the byte array
+         Schema.Type.BYTES -> callback(ByteBuffer.wrap(bytes.toByteArray()))
          else -> throw SerializationException("Cannot encode byte array when schema is ${schema.type}")
       }
 

--- a/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoderTest.kt
+++ b/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoderTest.kt
@@ -24,19 +24,19 @@ class ByteArrayEncoderTest : FunSpec({
    test("encode ByteArray to ByteBuffer to ") {
       val schema = Avro.default.schema(ByteArrayTest.serializer())
       Avro.default.toRecord(ByteArrayTest.serializer(), ByteArrayTest(byteArrayOf(1, 4, 9))) shouldBe
-         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9))
+         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9).rewind())
    }
 
    test("encode List<Byte> to ByteBuffer") {
       val schema = Avro.default.schema(ListByteTest.serializer())
       Avro.default.toRecord(ListByteTest.serializer(), ListByteTest(listOf(1, 4, 9))) shouldBe
-         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9))
+         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9).rewind())
    }
 
    test("encode Array<Byte> to ByteBuffer") {
       val schema = Avro.default.schema(ArrayByteTest.serializer())
       Avro.default.toRecord(ArrayByteTest.serializer(), ArrayByteTest(arrayOf(1, 4, 9))) shouldBe
-         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9))
+         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9).rewind())
    }
 
    test("encode ByteArray as FIXED when schema is Type.Fixed") {

--- a/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoderTest.kt
+++ b/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/encoder/ByteArrayEncoderTest.kt
@@ -24,19 +24,19 @@ class ByteArrayEncoderTest : FunSpec({
    test("encode ByteArray to ByteBuffer to ") {
       val schema = Avro.default.schema(ByteArrayTest.serializer())
       Avro.default.toRecord(ByteArrayTest.serializer(), ByteArrayTest(byteArrayOf(1, 4, 9))) shouldBe
-         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9).rewind())
+         ListRecord(schema, ByteBuffer.wrap(byteArrayOf(1,4,9)))
    }
 
    test("encode List<Byte> to ByteBuffer") {
       val schema = Avro.default.schema(ListByteTest.serializer())
       Avro.default.toRecord(ListByteTest.serializer(), ListByteTest(listOf(1, 4, 9))) shouldBe
-         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9).rewind())
+         ListRecord(schema, ByteBuffer.wrap(byteArrayOf(1,4,9)))
    }
 
    test("encode Array<Byte> to ByteBuffer") {
       val schema = Avro.default.schema(ArrayByteTest.serializer())
       Avro.default.toRecord(ArrayByteTest.serializer(), ArrayByteTest(arrayOf(1, 4, 9))) shouldBe
-         ListRecord(schema, ByteBuffer.allocate(3).put(1).put(4).put(9).rewind())
+         ListRecord(schema, ByteBuffer.wrap(byteArrayOf(1,4,9)))
    }
 
    test("encode ByteArray as FIXED when schema is Type.Fixed") {

--- a/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/io/BasicIoTest.kt
+++ b/avro4k-core/src/test/kotlin/com/sksamuel/avro4k/io/BasicIoTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.avro4k.io
 
+import com.sksamuel.avro4k.Avro
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FunSpec
 import kotlinx.serialization.Serializable
@@ -26,6 +27,9 @@ class BasicIoTest : FunSpec() {
       @Serializable
       data class LongTest(val z: Long)
 
+      @Suppress("ArrayInDataClass")
+      @Serializable
+      data class ByteArrayTest(val z : ByteArray)
       test("read write out booleans") {
          writeRead(BooleanTest(true), BooleanTest.serializer())
          writeRead(BooleanTest(false), BooleanTest.serializer()) {
@@ -60,6 +64,13 @@ class BasicIoTest : FunSpec() {
 
       test("read write out floats") {
          writeRead(FloatTest(3.4F), FloatTest.serializer())
+      }
+      test("read write out byte arrays") {
+         val expected = ByteArrayTest("ABC".toByteArray())
+         writeRead(expected,ByteArrayTest.serializer()){
+            val deserialized = Avro.default.fromRecord(ByteArrayTest.serializer(),it)
+            expected.z shouldBe deserialized.z
+         }
       }
    }
 }


### PR DESCRIPTION
This change will rewind all instances of `ByteBuffers` created by `ByteArrayEncoder` before returning the to the clients.

Fixes #55 