### PR TITLE
fix(confluent-kafka-serializer): Allow reading with a different schema than writer schema

### DIFF
--- a/confluent-kafka-serializer/src/main/kotlin/com/github/avrokotlin/avro4k/kafka/confluent/AbstractAvro4kKafkaSerde.kt
+++ b/confluent-kafka-serializer/src/main/kotlin/com/github/avrokotlin/avro4k/kafka/confluent/AbstractAvro4kKafkaSerde.kt
@@ -309,10 +309,8 @@ public abstract class AbstractAvro4kKafkaDeserializer<T : Any>(
     }
 
     override fun getDatumReader(writerSchema: Schema, readerSchema: Schema?): DatumReader<*> {
-        // a non-null reader schema means that this.schema returned a schema, so the user wants to always read a specific schema.
-        // confluent takes care of schema adaptations between writer and reader schema, so it always adapt the data to the reader schema
-        // by doing migrations before giving us the data to deserialize.
-        return avro.getDatumReader<Any>(readerSchema ?: writerSchema, deserializer)
+        // Avro4k natively supports schema evolution, and it needs to rely on the writer schema only to decode the data.
+        return avro.getDatumReader<Any>(writerSchema, deserializer)
     }
 
     @InternalAvro4kApi

--- a/confluent-kafka-serializer/src/test/kotlin/com/github/avrokotlin/avro4k/kafka/confluent/SpecificAvro4kKafkaDeserializerTest.kt
+++ b/confluent-kafka-serializer/src/test/kotlin/com/github/avrokotlin/avro4k/kafka/confluent/SpecificAvro4kKafkaDeserializerTest.kt
@@ -49,6 +49,23 @@ class SpecificAvro4kKafkaDeserializerTest : StringSpec() {
 
             deserialized shouldBe AnEnum.B
         }
+
+        "an payload written with a different schema than the reader one should be deserializable" {
+            @Serializable
+            data class Writer(val a: Int, val b: String)
+
+            @Serializable
+            data class Reader(val b: String)
+
+            val schemaRegistry = MockSchemaRegistryClient()
+            val writerSerializer = SpecificAvro4kKafkaSerializer<Writer>(isKey = false, schemaRegistry = schemaRegistry)
+            val bytes = writerSerializer.serialize("topic", Writer(42, "test"))
+            val readerDeserializer = SpecificAvro4kKafkaDeserializer<Reader>(isKey = false, schemaRegistry = schemaRegistry)
+
+            val deserialized = readerDeserializer.deserialize("topic", bytes)
+
+            deserialized shouldBe Reader("test")
+        }
     }
 }
 


### PR DESCRIPTION
Closes #383 