### PR TITLE
fix(gradle-plugin): Make the source generation compatible with the gradle config cache

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/github/avrokotlin/avro4k/plugin/gradle/Avro4kGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/avrokotlin/avro4k/plugin/gradle/Avro4kGradlePlugin.kt
@@ -122,13 +122,13 @@ public abstract class GenerateKotlinAvroSourcesTask : DefaultTask() {
         }
 
         files.associateWith { file ->
-            logger.info("Generating kotlin sources for schema file: ${file.relativeTo(project.projectDir)}")
+            logger.info("Generating kotlin sources for schema file: $file")
 
             val schemaContent = file.readText()
             kotlinGenerator.generateKotlinClasses(schemaContent, file.nameWithoutExtension)
                 .also { generatedFiles ->
                     logger.lifecycle(
-                        "Schema ${file.relativeTo(project.projectDir)} generated ${generatedFiles.size} class(es):\n  " + generatedFiles.joinToString("\n  ") { it.fullName() }
+                        "Schema $file generated ${generatedFiles.size} class(es):\n " + generatedFiles.joinToString("\n ") { it.fullName() }
                     )
                 }
         }
@@ -147,7 +147,7 @@ public abstract class GenerateKotlinAvroSourcesTask : DefaultTask() {
             .asFileTree
             .matching { include("**/*.avsc") }
             .files
-            .sortedBy { it.relativeTo(project.projectDir).invariantSeparatorsPath }
+            .sorted()
 
     private fun FileSpec.fullName() = if (packageName.isEmpty()) name else "$packageName.$name"
 
@@ -170,7 +170,7 @@ public abstract class GenerateKotlinAvroSourcesTask : DefaultTask() {
                     "Please check your input schema files:\n${
                         names.entries.joinToString("\n  ") { (generatedFullName, originalSchemaLocation) ->
                             "$generatedFullName has been generated differently from the following schemas: ${
-                                originalSchemaLocation.keys.joinToString(", ") { it.relativeTo(project.projectDir).path }
+                                originalSchemaLocation.keys.joinToString(", ") { it.path }
                             }"
                         }
                     }."


### PR DESCRIPTION
Changes to gradle plugin to not reference `Project` type in the task execution logic. I have tested myself.

Thanks for developing a very useful plugin by the way!