### PR TITLE
fix(plugin): Ensure generating @AvroDecimal

### DIFF
--- a/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationsHelper.kt
+++ b/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationsHelper.kt
@@ -42,17 +42,17 @@ internal fun buildAvroAliasAnnotation(carrier: WithAliases): AnnotationSpec? {
 }
 
 internal fun buildAvroDecimalAnnotation(schema: TypeSafeSchema): AnnotationSpec? {
-    if (schema !is TypeSafeSchema.NamedSchema.FixedSchema || schema.logicalTypeName != "decimal") {
-        return null
-    }
-    val scale: Int? by schema.props
-    val precision: Int? by schema.props
-    precision ?: error("Missing 'precision' prop for 'decimal' logical type of schema $schema")
+    if ((schema is TypeSafeSchema.NamedSchema.FixedSchema || schema is TypeSafeSchema.PrimitiveSchema.BytesSchema) && schema.logicalTypeName == "decimal") {
+        val scale: Int? by schema.props
+        val precision: Int? by schema.props
+        precision ?: error("Missing 'precision' prop for 'decimal' logical type of schema $schema")
 
-    return AnnotationSpec.builder(AvroDecimal::class.asClassName())
-        .addMember(CodeBlock.of("${AvroDecimal::scale.name} = %L", scale ?: 0))
-        .addMember(CodeBlock.of("${AvroDecimal::precision.name} = %L", precision))
-        .build()
+        return AnnotationSpec.builder(AvroDecimal::class.asClassName())
+            .addMember(CodeBlock.of("${AvroDecimal::scale.name} = %L", scale ?: 0))
+            .addMember(CodeBlock.of("${AvroDecimal::precision.name} = %L", precision))
+            .build()
+    }
+    return null
 }
 
 internal fun buildAvroGeneratedAnnotation(schemaStr: String): AnnotationSpec {

--- a/kotlin-generator/src/test/expected-sources/nested-logicalType-decimal-bytes/NestedLogicalTypeDecimalBytes.kt
+++ b/kotlin-generator/src/test/expected-sources/nested-logicalType-decimal-bytes/NestedLogicalTypeDecimalBytes.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroDecimal
 import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.AvroDoc
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
@@ -22,6 +23,10 @@ public data class NestedLogicalTypeDecimalBytes(
      * Default value: null
      */
     @AvroDoc("A nullable decimal field")
+    @AvroDecimal(
+        scale = 4,
+        precision = 10,
+    )
     @AvroDefault("null")
     @Serializable(with = BigDecimalSerializer::class)
     public val amount: BigDecimal?,

--- a/kotlin-generator/src/test/expected-sources/root-logicalType-decimal-bytes/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-logicalType-decimal-bytes/TestSchema.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroDecimal
 import com.github.avrokotlin.avro4k.AvroProp
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -17,6 +18,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""{"type":"bytes","logicalType":"decimal","precision":10,"scale":4}""")
 public value class TestSchema(
+    @AvroDecimal(
+        scale = 4,
+        precision = 10,
+    )
     @AvroProp("logicalType", "decimal")
     @AvroProp("precision", "10")
     @AvroProp("scale", "4")


### PR DESCRIPTION
The decimal values are well serialized as the parent class has @AvroGenerated including the original schema, used for serialization instead of a generated one at runtime.