### PR TITLE
Fix artifactId for kafka serializer

### DIFF
--- a/confluent-kafka-serializer/README.md
+++ b/confluent-kafka-serializer/README.md
@@ -58,7 +58,7 @@ For reflection deserialization, it will be a little bit more specific:
 
 Add the dependency to your project:
 ```kotlin
-implementation("com.github.avro-kotlin.avro4k:confluent-kafka-serializer:<latest-version>")
+implementation("com.github.avro-kotlin.avro4k:avro4k-confluent-kafka-serializer:<latest-version>")
 ```
 
 There are 3 types of serialization:


### PR DESCRIPTION
Cheers,

just a minor thing: In the `confluent-kafka-serializer/README.md` is the wrong GAV:

```
implementation("com.github.avro-kotlin.avro4k:confluent-kafka-serializer:<latest-version>")
```

It didn't find it under this name and notices your publishing convention adds an "avro4k-" prefix to your artifacts. Therefore it should be:

```
implementation("com.github.avro-kotlin.avro4k:avro4k-confluent-kafka-serializer:<latest-version>")
```

Kind regards