### PR TITLE
fix(plugin): do not annotate with @AvroDefault for implicit values

### DIFF
--- a/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationsHelper.kt
+++ b/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/AnnotationsHelper.kt
@@ -74,26 +74,9 @@ internal fun buildAvroDefaultAnnotation(field: AvroSchema.RecordSchema.Field): A
     if (field.defaultValue == null) {
         return null
     }
-    return buildAvroDefaultAnnotation(field.defaultValue.contentUnquoted)
-}
-
-private fun buildAvroDefaultAnnotation(unquotedDefaultValue: String): AnnotationSpec {
     return AnnotationSpec.builder(AvroDefault::class.asClassName())
-        .addMember("%S", unquotedDefaultValue)
+        .addMember("%S", field.defaultValue.contentUnquoted)
         .build()
-}
-
-internal fun buildImplicitAvroDefaultAnnotation(schema: AvroSchema, implicitNulls: Boolean, implicitEmptyCollections: Boolean): AnnotationSpec? {
-    if (implicitNulls && schema.isNullable) {
-        return buildAvroDefaultAnnotation("null")
-    } else if (implicitEmptyCollections) {
-        if (schema is AvroSchema.ArraySchema) {
-            return buildAvroDefaultAnnotation("[]")
-        } else if (schema is AvroSchema.MapSchema) {
-            return buildAvroDefaultAnnotation("{}")
-        }
-    }
-    return null
 }
 
 internal fun buildImplicitAvroDefaultCodeBlock(schema: AvroSchema, implicitNulls: Boolean, implicitEmptyCollections: Boolean): CodeBlock? {

--- a/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
+++ b/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
@@ -201,7 +201,6 @@ public class KotlinGenerator(
                     .addAnnotationIfNotNull(buildAvroDecimalAnnotation(nonNullSchema))
                     .addAnnotationIfNotNull(buildAvroFixedAnnotation(nonNullSchema))
                     .addAnnotations((nonNullSchema as? WithProps)?.let { buildAvroPropAnnotations(it) } ?: emptyList())
-                    .addAnnotationIfNotNull(buildImplicitAvroDefaultAnnotation(schema, implicitNulls = implicitNulls, implicitEmptyCollections = implicitEmptyCollections))
                     .build(),
                 defaultValue = buildImplicitAvroDefaultCodeBlock(schema, implicitNulls = implicitNulls, implicitEmptyCollections = implicitEmptyCollections)
             )

--- a/kotlin-generator/src/test/expected-sources/root-array/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-array/TestSchema.kt
@@ -3,7 +3,6 @@
     ExperimentalAvro4kApi::class,
 )
 
-import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.AvroProp
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -20,6 +19,5 @@ import kotlinx.serialization.Serializable
 @AvroGenerated("""{"type":"array","items":["double","null","int"],"java-element-class":"java.lang.Double"}""")
 public value class TestSchema(
     @AvroProp("java-element-class", "java.lang.Double")
-    @AvroDefault("[]")
     public val `value`: List<Double?> = emptyList(),
 )

--- a/kotlin-generator/src/test/expected-sources/root-logicalType-timestamp-micros-nullable/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-logicalType-timestamp-micros-nullable/TestSchema.kt
@@ -3,7 +3,6 @@
     ExperimentalAvro4kApi::class,
 )
 
-import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.AvroProp
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -19,6 +18,5 @@ import kotlinx.serialization.Serializable
 @AvroGenerated("""[{"type":"long","logicalType":"timestamp-micros"},"null"]""")
 public value class TestSchema(
     @AvroProp("logicalType", "timestamp-micros")
-    @AvroDefault("null")
     public val `value`: @Serializable(with = InstantSerializer::class) Instant? = null,
 )

--- a/kotlin-generator/src/test/expected-sources/root-long-nullable/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-long-nullable/TestSchema.kt
@@ -3,7 +3,6 @@
     ExperimentalAvro4kApi::class,
 )
 
-import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -16,6 +15,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["long","null"]""")
 public value class TestSchema(
-    @AvroDefault("null")
     public val `value`: Long? = null,
 )

--- a/kotlin-generator/src/test/expected-sources/root-map/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-map/TestSchema.kt
@@ -3,7 +3,6 @@
     ExperimentalAvro4kApi::class,
 )
 
-import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.AvroProp
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -20,6 +19,5 @@ import kotlinx.serialization.Serializable
 @AvroGenerated("""{"type":"map","values":["double","null","int"],"java-key-class":"java.lang.Integer"}""")
 public value class TestSchema(
     @AvroProp("java-key-class", "java.lang.Integer")
-    @AvroDefault("{}")
     public val `value`: Map<Int, TestSchemaMapUnion?> = emptyMap(),
 )

--- a/kotlin-generator/src/test/expected-sources/root-record-nullable/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-record-nullable/TestSchema.kt
@@ -3,7 +3,6 @@
     ExperimentalAvro4kApi::class,
 )
 
-import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -15,6 +14,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["null",{"type":"record","name":"Test","fields":[{"name":"field","type":"string"}]}]""")
 public value class TestSchema(
-    @AvroDefault("null")
     public val `value`: Test? = null,
 )


### PR DESCRIPTION
@AvroDefault implies that the schema includes this default value, while it does not exist in the original schema as it is an implicit value present in case of no actual default
