### PR TITLE
fix(kotlin-generator): prevent stackoverflow where a record is used inside itself in a simple/nullable union

### DIFF
--- a/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
+++ b/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
@@ -228,7 +228,7 @@ public class KotlinGenerator(
                         schema.fields.flatMap { field ->
                             // the union schema is already generated as a subtype of the record, no need to generate it again. However, we need to generate the types used in the union
                             if (field.schema is AvroSchema.UnionSchema) {
-                                field.schema.types.flatMap { generateNestedKotlinClasses(it, potentialAnonymousBaseName, generatedRecords) }
+                                field.schema.types.flatMap { generateNestedKotlinClasses(it, potentialAnonymousBaseName, generatedRecords + (schema.asClassName() to recordType)) }
                             } else {
                                 generateNestedKotlinClasses(field.schema, field.name.toPascalCase(), generatedRecords + (schema.asClassName() to recordType))
                             }

--- a/kotlin-generator/src/test/expected-sources/nested-union/ns/theNestedUnion.kt
+++ b/kotlin-generator/src/test/expected-sources/nested-union/ns/theNestedUnion.kt
@@ -1,0 +1,28 @@
+@file:OptIn(
+    InternalAvro4kApi::class,
+    ExperimentalAvro4kApi::class,
+)
+
+package ns
+
+import com.github.avrokotlin.avro4k.AvroDefault
+import com.github.avrokotlin.avro4k.AvroDoc
+import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
+import com.github.avrokotlin.avro4k.InternalAvro4kApi
+import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
+import kotlin.OptIn
+import kotlinx.serialization.Serializable
+
+/**
+ * doc
+ */
+@Serializable
+@AvroDoc("doc")
+@AvroGenerated("""{"type":"record","name":"theNestedUnion","namespace":"ns","doc":"doc","fields":[{"name":"s","type":["null","theNestedUnion"],"default":null}]}""")
+public data class theNestedUnion(
+    /**
+     * Default value: null
+     */
+    @AvroDefault("null")
+    public val s: theNestedUnion? = null,
+)

--- a/kotlin-generator/src/test/resources/nested-union.avsc
+++ b/kotlin-generator/src/test/resources/nested-union.avsc
@@ -6,7 +6,10 @@
     "fields": [
         {
             "name": "s",
-            "type": ["null", "ns.theNestedUnion"],
+            "type": [
+                "null",
+                "ns.theNestedUnion"
+            ],
             "default": null
         }
     ]

--- a/kotlin-generator/src/test/resources/nested-union.avsc
+++ b/kotlin-generator/src/test/resources/nested-union.avsc
@@ -1,0 +1,13 @@
+{
+    "type": "record",
+    "name": "theNestedUnion",
+    "namespace": "ns",
+    "doc": "doc",
+    "fields": [
+        {
+            "name": "s",
+            "type": ["null", "ns.theNestedUnion"],
+            "default": null
+        }
+    ]
+}


### PR DESCRIPTION
This would generate a StackOverflowException in the previous code.