### PR TITLE
fix(kotlin-generator): add @AvroAlias on union subtype wrappers

### DIFF
--- a/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
+++ b/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
@@ -357,7 +357,7 @@ public class KotlinGenerator(
                         TypeSpec.classBuilder(unionSubTypeNameFormatter(if (hasSimilarNames) subSchema.fullName else subSchema.simpleName.toPascalCase()))
                             .addSuperinterface(ClassName.fromFullName(className))
                             .addModifiers(KModifier.VALUE)
-                            .addAnnotation(buildAvroAliasAnnotation(listOf(subSchema.fullName))!!)
+                            .addAnnotationIfNotNull(buildAvroAliasAnnotation(listOf(subSchema.fullName)))
                             .addAnnotation(JvmInline::class)
                             .addAnnotation(Serializable::class)
                             .addPrimaryProperty(

--- a/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
+++ b/kotlin-generator/src/main/kotlin/com/github/avrokotlin/avro4k/KotlinGenerator.kt
@@ -332,6 +332,7 @@ public class KotlinGenerator(
      * ```kotlin
      * @Serializable
      * sealed interface <potentialAnonymousBaseName>Union {
+     *     @AvroAlias("<Type full name>")
      *     @JvmInline
      *     @Serializable
      *     value class For<Type name>(val value: <Type full name>) : <potentialAnonymousBaseName>Union
@@ -356,6 +357,7 @@ public class KotlinGenerator(
                         TypeSpec.classBuilder(unionSubTypeNameFormatter(if (hasSimilarNames) subSchema.fullName else subSchema.simpleName.toPascalCase()))
                             .addSuperinterface(ClassName.fromFullName(className))
                             .addModifiers(KModifier.VALUE)
+                            .addAnnotation(buildAvroAliasAnnotation(listOf(subSchema.fullName))!!)
                             .addAnnotation(JvmInline::class)
                             .addAnnotation(Serializable::class)
                             .addPrimaryProperty(

--- a/kotlin-generator/src/test/expected-sources/complex-union-in-record/ComplexUnionInRecord.kt
+++ b/kotlin-generator/src/test/expected-sources/complex-union-in-record/ComplexUnionInRecord.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.AvroDefault
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -25,18 +26,21 @@ public data class ComplexUnionInRecord(
     @Serializable
     @AvroGenerated("""["null",{"type":"record","name":"NestedRecord","fields":[{"name":"id","type":"string"},{"name":"value","type":"int"}]},{"type":"enum","name":"Status","symbols":["ACTIVE","INACTIVE","PENDING"]},{"type":"array","items":"string"}]""")
     public sealed interface TheFieldUnion {
+        @AvroAlias("NestedRecord")
         @JvmInline
         @Serializable
         public value class ForNestedRecord(
             public val `value`: NestedRecord,
         ) : TheFieldUnion
 
+        @AvroAlias("Status")
         @JvmInline
         @Serializable
         public value class ForStatus(
             public val `value`: Status,
         ) : TheFieldUnion
 
+        @AvroAlias("array")
         @JvmInline
         @Serializable
         public value class ForArray(

--- a/kotlin-generator/src/test/expected-sources/field-naming-camel-case/ns/CamelCaseRecord.kt
+++ b/kotlin-generator/src/test/expected-sources/field-naming-camel-case/ns/CamelCaseRecord.kt
@@ -48,12 +48,14 @@ public data class CamelCaseRecord(
     @Serializable
     @AvroGenerated("""["string",{"type":"enum","name":"StatusFlag","namespace":"ns","symbols":["ACTIVE","INACTIVE"]},"null"]""")
     public sealed interface AccountStatusUnion {
+        @AvroAlias("string")
         @JvmInline
         @Serializable
         public value class ForString(
             public val `value`: String,
         ) : AccountStatusUnion
 
+        @AvroAlias("ns.StatusFlag")
         @JvmInline
         @Serializable
         public value class ForStatusFlag(

--- a/kotlin-generator/src/test/expected-sources/root-complex-union/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-complex-union/TestSchema.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.AvroFixed
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -20,30 +21,35 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["null","string","int",{"type":"record","name":"NestedRecord","fields":[{"name":"field","type":"string","doc":"field doc"}]},{"type":"enum","name":"AnEnum","symbols":["A","B","C"]},{"type":"fixed","name":"AFixed","size":5},{"type":"array","items":"int"},{"type":"map","values":["null","double"]}]""")
 public sealed interface TestSchema {
+    @AvroAlias("string")
     @JvmInline
     @Serializable
     public value class ForString(
         public val `value`: String,
     ) : TestSchema
 
+    @AvroAlias("int")
     @JvmInline
     @Serializable
     public value class ForInt(
         public val `value`: Int,
     ) : TestSchema
 
+    @AvroAlias("NestedRecord")
     @JvmInline
     @Serializable
     public value class ForNestedRecord(
         public val `value`: NestedRecord,
     ) : TestSchema
 
+    @AvroAlias("AnEnum")
     @JvmInline
     @Serializable
     public value class ForAnEnum(
         public val `value`: AnEnum,
     ) : TestSchema
 
+    @AvroAlias("AFixed")
     @JvmInline
     @Serializable
     public value class ForAFixed(
@@ -51,12 +57,14 @@ public sealed interface TestSchema {
         public val `value`: ByteArray,
     ) : TestSchema
 
+    @AvroAlias("array")
     @JvmInline
     @Serializable
     public value class ForArray(
         public val `value`: List<Int>,
     ) : TestSchema
 
+    @AvroAlias("map")
     @JvmInline
     @Serializable
     public value class ForMap(

--- a/kotlin-generator/src/test/expected-sources/root-map/TestSchemaMapUnion.kt
+++ b/kotlin-generator/src/test/expected-sources/root-map/TestSchemaMapUnion.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -15,12 +16,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["double","null","int"]""")
 public sealed interface TestSchemaMapUnion {
+    @AvroAlias("double")
     @JvmInline
     @Serializable
     public value class ForDouble(
         public val `value`: Double,
     ) : TestSchemaMapUnion
 
+    @AvroAlias("int")
     @JvmInline
     @Serializable
     public value class ForInt(

--- a/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchema.kt
+++ b/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchema.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -17,18 +18,21 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["int","null",{"type":"map","values":["string","null",{"type":"array","items":["long","null",{"type":"map","values":["boolean","null"]}]}]},{"type":"array","items":["long","null","double"]}]""")
 public sealed interface TestSchema {
+    @AvroAlias("int")
     @JvmInline
     @Serializable
     public value class ForInt(
         public val `value`: Int,
     ) : TestSchema
 
+    @AvroAlias("map")
     @JvmInline
     @Serializable
     public value class ForMap(
         public val `value`: Map<String, TestSchemaMapUnion?>,
     ) : TestSchema
 
+    @AvroAlias("array")
     @JvmInline
     @Serializable
     public value class ForArray(

--- a/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchemaArrayUnion.kt
+++ b/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchemaArrayUnion.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -15,12 +16,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["long","null","double"]""")
 public sealed interface TestSchemaArrayUnion {
+    @AvroAlias("long")
     @JvmInline
     @Serializable
     public value class ForLong(
         public val `value`: Long,
     ) : TestSchemaArrayUnion
 
+    @AvroAlias("double")
     @JvmInline
     @Serializable
     public value class ForDouble(

--- a/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchemaMapArrayUnion.kt
+++ b/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchemaMapArrayUnion.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -17,12 +18,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["long","null",{"type":"map","values":["boolean","null"]}]""")
 public sealed interface TestSchemaMapArrayUnion {
+    @AvroAlias("long")
     @JvmInline
     @Serializable
     public value class ForLong(
         public val `value`: Long,
     ) : TestSchemaMapArrayUnion
 
+    @AvroAlias("map")
     @JvmInline
     @Serializable
     public value class ForMap(

--- a/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchemaMapUnion.kt
+++ b/kotlin-generator/src/test/expected-sources/root-union-with-nested-map-and-array-unions/TestSchemaMapUnion.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
 import com.github.avrokotlin.avro4k.`internal`.AvroGenerated
@@ -15,12 +16,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 @AvroGenerated("""["string","null",{"type":"array","items":["long","null",{"type":"map","values":["boolean","null"]}]}]""")
 public sealed interface TestSchemaMapUnion {
+    @AvroAlias("string")
     @JvmInline
     @Serializable
     public value class ForString(
         public val `value`: String,
     ) : TestSchemaMapUnion
 
+    @AvroAlias("array")
     @JvmInline
     @Serializable
     public value class ForArray(

--- a/kotlin-generator/src/test/expected-sources/types-across-multiple-files/Union.kt
+++ b/kotlin-generator/src/test/expected-sources/types-across-multiple-files/Union.kt
@@ -3,6 +3,7 @@
     ExperimentalAvro4kApi::class,
 )
 
+import com.github.avrokotlin.avro4k.AvroAlias
 import com.github.avrokotlin.avro4k.AvroFixed
 import com.github.avrokotlin.avro4k.ExperimentalAvro4kApi
 import com.github.avrokotlin.avro4k.InternalAvro4kApi
@@ -18,24 +19,28 @@ import ns2.Enum
 @Serializable
 @AvroGenerated("""[{"type":"record","name":"Record","namespace":"ns","fields":[{"name":"field","type":"int"}]},{"type":"record","name":"RecordWithoutNamespace","fields":[{"name":"field","type":"int"}]},{"type":"enum","name":"Enum","namespace":"ns2","symbols":["FIRST","SECOND"]},{"type":"fixed","name":"FixedType","size":12},"string","bytes"]""")
 public sealed interface Union {
+    @AvroAlias("ns.Record")
     @JvmInline
     @Serializable
     public value class ForRecord(
         public val `value`: Record,
     ) : Union
 
+    @AvroAlias("RecordWithoutNamespace")
     @JvmInline
     @Serializable
     public value class ForRecordWithoutNamespace(
         public val `value`: RecordWithoutNamespace,
     ) : Union
 
+    @AvroAlias("ns2.Enum")
     @JvmInline
     @Serializable
     public value class ForEnum(
         public val `value`: Enum,
     ) : Union
 
+    @AvroAlias("FixedType")
     @JvmInline
     @Serializable
     public value class ForFixedType(
@@ -43,12 +48,14 @@ public sealed interface Union {
         public val `value`: ByteArray,
     ) : Union
 
+    @AvroAlias("string")
     @JvmInline
     @Serializable
     public value class ForString(
         public val `value`: String,
     ) : Union
 
+    @AvroAlias("bytes")
     @JvmInline
     @Serializable
     public value class ForBytes(


### PR DESCRIPTION
## Summary

Value-class wrappers generated inside a sealed interface for a complex Avro union had no `@AvroAlias` pointing at the inner Avro full name, so `PolymorphicResolver` could not map the incoming schema `fullName` (e.g. `com.example.MyRecord`, `int`, `map`) to the wrapper `SerialName` (`ForMyRecord`, `ForInt`, `ForMap`) at runtime.

This caused `SerializationException: Serializer for subclass ... is not found` on decode for every multi-type union.

## Fix

Emit `@AvroAlias(subSchema.fullName)` on each value-class wrapper so `AbstractPolymorphicDecoder` can resolve the subtype via the existing alias lookup in `PolymorphicResolver` (see `core/src/main/kotlin/com/github/avrokotlin/avro4k/internal/PolymorphicResolver.kt`).

## Before

```kotlin
public sealed interface TestSchema {
    @JvmInline
    @Serializable
    public value class ForString(public val `value`: String) : TestSchema
    // ...
}
```

## After

```kotlin
public sealed interface TestSchema {
    @AvroAlias("string")
    @JvmInline
    @Serializable
    public value class ForString(public val `value`: String) : TestSchema
    // ...
}
```

## Test evidence

- `expected-sources` fixtures updated automatically by the local `updateExpectedGeneratedSources` test path.
- `CI=true ./gradlew test` passes across all modules (`core`, `kotlin-generator`, `gradle-plugin`, `confluent-kafka-serializer`).

## Notes

Applies to every `fullName`-bearing subschema (records, enums, fixed, and primitives/arrays/maps whose `fullName == simpleName`). No behavioural change for single-type or nullable-only unions (they do not hit `generateSealedInterface`).